### PR TITLE
Implemented password hashing and salting on the Server Side

### DIFF
--- a/bookstore_table_data.sql
+++ b/bookstore_table_data.sql
@@ -44,10 +44,6 @@ delete from IMS_Members;
 delete from IMS_Books;
 delete from IMS_Checkout;
 
--- Populate Members table
-INSERT INTO IMS_Members (UserName, UserType, Pass) VALUES
-('coreydc7','Admin','password'),('FrostyNoFace','Admin','pass123'),('Corey','Member','password'),('Colton','Member','pass123');
-
 -- Populate Books table
 INSERT INTO IMS_Books (BookID, Title, Publisher, ISBN, Format, BookLanguage, Lexile) VALUES
 (1,'The Hobbit (The Lord of the Rings)','Clarion Books; Young Reader ed. edition (August 15, 2002)','978-0618260300','Paperback','English',1000),

--- a/demoapp/pom.xml
+++ b/demoapp/pom.xml
@@ -48,6 +48,12 @@
         <version>3.1.0</version>
         <scope>provided</scope>
     </dependency>
+    
+    <dependency>
+    <groupId>org.mindrot</groupId>
+    <artifactId>jbcrypt</artifactId>
+    <version>0.4</version>
+</dependency>
   </dependencies>
 
   <build>

--- a/demoapp/src/main/java/com/bs/ims/JDBC_Authentication.java
+++ b/demoapp/src/main/java/com/bs/ims/JDBC_Authentication.java
@@ -4,8 +4,8 @@ public class JDBC_Authentication {
     // Populate these fields with Database Connection information for JDBC
 
     private static final String JDBC_URL = "jdbc:mysql://faure.cs.colostate.edu:3306/coreydc";
-    private static final String JDBC_USERNAME = "";
-    private static final String JDBC_PASSWORD = "";
+    private static final String JDBC_USERNAME = "coreydc";
+    private static final String JDBC_PASSWORD = "835870365";
 
     public String getURL() {
         return JDBC_URL;

--- a/demoapp/src/main/java/com/bs/ims/JDBC_Authentication.java
+++ b/demoapp/src/main/java/com/bs/ims/JDBC_Authentication.java
@@ -4,8 +4,8 @@ public class JDBC_Authentication {
     // Populate these fields with Database Connection information for JDBC
 
     private static final String JDBC_URL = "jdbc:mysql://faure.cs.colostate.edu:3306/coreydc";
-    private static final String JDBC_USERNAME = "coreydc";
-    private static final String JDBC_PASSWORD = "835870365";
+    private static final String JDBC_USERNAME = "";
+    private static final String JDBC_PASSWORD = "";
 
     public String getURL() {
         return JDBC_URL;

--- a/demoapp/src/main/java/com/bs/ims/JavaServlets/MemberLoginServlet.java
+++ b/demoapp/src/main/java/com/bs/ims/JavaServlets/MemberLoginServlet.java
@@ -13,6 +13,7 @@ import java.io.BufferedReader;
 
 import main.java.com.bs.ims.JDBC_Authentication;
 import main.java.com.bs.ims.model.Member;
+import main.java.com.bs.ims.model.HashPassword;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -50,6 +51,9 @@ public class MemberLoginServlet extends HttpServlet {
         String username = jsonObject.get("username").getAsString();
         String password = jsonObject.get("password").getAsString();
 
+        // Hash password
+        String hashedPassword = HashPassword.hashPassword(password);
+
         Member memberResult = null;
         Connection connection = null;
         PreparedStatement statement = null;
@@ -69,7 +73,7 @@ public class MemberLoginServlet extends HttpServlet {
             String sql = "SELECT * FROM IMS_Members WHERE UserName = ? AND Pass = ?";
             statement = connection.prepareStatement(sql);
             statement.setString(1,username);
-            statement.setString(2,password);
+            statement.setString(2,hashedPassword);
 
             // Execute Query and store in ResultSet
             resultSet = statement.executeQuery();

--- a/demoapp/src/main/java/com/bs/ims/JavaServlets/MemberRegisterServlet.java
+++ b/demoapp/src/main/java/com/bs/ims/JavaServlets/MemberRegisterServlet.java
@@ -13,6 +13,7 @@ import java.io.BufferedReader;
 
 import main.java.com.bs.ims.JDBC_Authentication;
 import main.java.com.bs.ims.model.Member;
+import main.java.com.bs.ims.model.HashPassword;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -54,6 +55,9 @@ public class MemberRegisterServlet extends HttpServlet {
         PreparedStatement statement = null;
         ResultSet resultSet = null;
 
+        // Hash and Salt the password using BCrypt
+        String hashedPassword = HashPassword.hashPassword(password);
+
         try {
             Class.forName("com.mysql.cj.jdbc.Driver");
         } catch (ClassNotFoundException e) {
@@ -69,7 +73,7 @@ public class MemberRegisterServlet extends HttpServlet {
             statement = connection.prepareStatement(sql);
             statement.setString(1,username);
             statement.setString(2,"Member");
-            statement.setString(3,password);
+            statement.setString(3,hashedPassword);
 
             // Execute Update Query
             int rowsAffected = statement.executeUpdate();

--- a/demoapp/src/main/java/com/bs/ims/model/HashPassword.java
+++ b/demoapp/src/main/java/com/bs/ims/model/HashPassword.java
@@ -1,0 +1,16 @@
+package main.java.com.bs.ims.model;
+
+import org.mindrot.jbcrypt.BCrypt;
+
+public class HashPassword {
+    // The higher the workFactor, the more secure but slower the hash
+    private static final int workFactor = 12;
+
+    public static String hashPassword(String plainTextPassword) {
+        return BCrypt.hashpw(plainTextPassword, BCrypt.gensalt(workFactor));
+    }
+
+    public static boolean checkPassword(String plainTextPassword, String hashedPassword) {
+        return BCrypt.checkpw(plainTextPassword, hashedPassword);
+    }
+}

--- a/demoapp/src/main/webapp/script.js
+++ b/demoapp/src/main/webapp/script.js
@@ -83,9 +83,6 @@ function handleLoginAttempt(data) {
         sessionStorage.setItem('isLoggedIn','true');
         sessionStorage.setItem('loginName',data.username);
         sessionStorage.setItem('loginType',data.type);
-
-        // Debug
-        console.log(checkLoginState());
         
         updateNavbar();
         loginResultDiv.innerHTML = "Successfully logged in as " + data.username + " - " + data.type;


### PR DESCRIPTION
Added dependency for BCrypt into pom.xml. Closes #26.
BCrypt allows for hashing and salting of passwords on the server side.
BCrypt automatically generates and stores a unique salt for each password, which is crucial for security.
The workFactor determines how computationally intensive the hashing process is.

This greatly improves the security of this application, as we are now salting and hashing members passwords before storing them in the database alongside using SQL Prepared Statements in order to provide input validation for user entered text in all fields. 
If this were a live application we would simply purchase, configure, then install a SSL certificate on our Apache server to ensure passwords are sent from client to server side using HTTPS. 